### PR TITLE
Add support for OpenShift hosting

### DIFF
--- a/env.js
+++ b/env.js
@@ -23,10 +23,10 @@ var url = require("url");
 var config = require('./config.json');
 
 // the IP address of the Cloud Foundry DEA (Droplet Execution Agent) that hosts this application:
-exports.listenHost = (process.env.VCAP_APP_HOST || config.host);
+exports.listenHost = (process.env.VCAP_APP_HOST || process.env.OPENSHIFT_NODEJS_IP || config.host);
 
 // the port on the DEA for communication with the application:
-exports.listenPort = (process.env.VCAP_APP_PORT || config.port);
+exports.listenPort = (process.env.VCAP_APP_PORT || process.env.OPENSHIFT_NODEJS_PORT || config.port);
 
 function addSlash(url) {
 	if (url.substr(-1) == '/') {
@@ -94,5 +94,9 @@ if (process.env.VCAP_SERVICES) {
 	var env = JSON.parse(process.env.VCAP_SERVICES);
 	exports.mongoURL = env.mongolab[0].credentials.uri;
 } else {
-	exports.mongoURL = process.env.MONGO_URL || config.mongoURL;
+	if (process.env.OPENSHIFT_MONGODB_DB_URL) {
+		exports.mongoURL = process.env.OPENSHIFT_MONGODB_DB_URL;
+	} else {
+		exports.mongoURL = process.env.MONGO_URL || config.mongoURL;
+	}
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
 	},
 	"engines": {
 		"node": "0.10.26"
+
+	},
+	"scripts": {  
+	   "start": "node app.js"
 	},
 	"repository": {}
+
 }

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
 
     <h1><a href="http://www.w3.org/2012/ldp/" title="LDP">Linked Data Platform</a> Reference Implementation</h1>
     <h3>This impl is an experiment using Node.JS and
-	MongoDB, hosted on bluemix.net, to build and host an LDP reference
+	MongoDB, hosted on a PaaS, to build and host an LDP reference
 	impl.</h3>
 	<p style="margin-left: 3em"><em>Enjoy.</em> Oh, and <a href="https://github.com/spadgett/LDPjs">here's the source</a>.</p>
 

--- a/server.js
+++ b/server.js
@@ -1,0 +1,1 @@
+require("./app.js");


### PR DESCRIPTION
Allow deploys to different node paas

Startup cmd

Add support for openshift env

Added support for openshift hosted mongo

Simple hack to debug/try mongo connection

Fix problem with text that assumed hosting

Added mongodb config settings for new OSO account

Use more flexible MONGODB_DB_URL env var
